### PR TITLE
setup.cfg: use underscores for identifiers

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,11 +1,11 @@
 [metadata]
 name = pysol_cards
 summary = Deal PySol FC Cards
-description-file =
+description_file =
     README.rst
 author = Shlomi Fish
-author-email = shlomif@cpan.org
-home-page = https://fc-solve.shlomifish.org/
+author_email = shlomif@cpan.org
+home_page = https://fc-solve.shlomifish.org/
 classifier =
     Intended Audience :: Developers
     License :: OSI Approved :: MIT License


### PR DESCRIPTION
Hyphens are deprecated in newer versions of setuptools:
```
* Usage of dash-separated 'author-email' will not be supported in future versions. Please use the underscore name 'author_email' instead
* Usage of dash-separated 'description-file' will not be supported in future versions. Please use the underscore name 'description_file' instead
* Usage of dash-separated 'home-page' will not be supported in future versions. Please use the underscore name 'home_page' instead
```

Tweaked setup.cfg to use underscores intead.

Bug: https://bugs.gentoo.org/796416
Signed-off-by: Sam James <sam@gentoo.org>